### PR TITLE
Fixes #5: keyboard shortcut to navigate up in the file browser

### DIFF
--- a/packages/apputils/src/dialog.ts
+++ b/packages/apputils/src/dialog.ts
@@ -69,8 +69,11 @@ export class Dialog<T> extends Widget {
   constructor(options: Partial<Dialog.IOptions<T>> = {}) {
     super();
     this.addClass('jp-Dialog');
+
+    // Add attributes for accessibility with screen readers 
     this.node.setAttribute('aria-modal', 'true');
     this.node.setAttribute('role', 'dialog');
+
     let normalized = Private.handleOptions(options);
     let renderer = normalized.renderer;
 

--- a/packages/apputils/src/dialog.ts
+++ b/packages/apputils/src/dialog.ts
@@ -69,6 +69,8 @@ export class Dialog<T> extends Widget {
   constructor(options: Partial<Dialog.IOptions<T>> = {}) {
     super();
     this.addClass('jp-Dialog');
+    this.node.setAttribute('aria-modal', 'true');
+    this.node.setAttribute('role', 'dialog');
     let normalized = Private.handleOptions(options);
     let renderer = normalized.renderer;
 

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -931,7 +931,16 @@ export class DirListing extends Widget {
 
         break;
       case 38: // Up arrow
-        this.selectPrevious(event.shiftKey);
+        if (event.altKey || event.ctrlKey || event.metaKey) {
+          // Up arrow + modifier (except shit) -> go up a directory
+          let path = '/' + this._manager.services.contents.localPath(this._model.path);
+          // Remove the last component of the path => parent directory
+          path = path.replace(/\/[^\/]+$/, '') || '/';
+          this._model.cd(path)
+            .catch(error => showErrorMessage('Open directory', error));
+        } else {
+          this.selectPrevious(event.shiftKey);
+        }
         event.stopPropagation();
         event.preventDefault();
         break;


### PR DESCRIPTION
## References

Issue #5 


## Code changes

## User-facing changes

In the file browser, then the up arrow key is pressed along with a modifier key (alt/option, command or control), the file browser will navigate *up* the file hierarchy

## Backwards-incompatible changes

