### PR TITLE
Make the "go to parent" shortcut platform specific

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -931,8 +931,11 @@ export class DirListing extends Widget {
 
         break;
       case 38: // Up arrow
-        if (event.altKey || event.ctrlKey || event.metaKey) {
-          // Up arrow + modifier (except shit) -> go up a directory
+        if ((IS_MAC && event.metaKey) || event.altKey) {
+          // Up arrow + command (on macOS) or up arrow + alt (on Windows) 
+          // -> go up a directory
+          // Note that those are the shortcuts used by the Finder and Windows
+          // Explorer, respectively.
           let path = '/' + this._manager.services.contents.localPath(this._model.path);
           // Remove the last component of the path => parent directory
           path = path.replace(/\/[^\/]+$/, '') || '/';


### PR DESCRIPTION
## References
Follow up to the previous PR for Issue #5 

## Code changes
The keyboard shortcut now checks the platform (mac or not) and will use command+up arrow on macOS and alt+up arrow on Windows.

## User-facing changes
To go the parent:
- Command+up arrow on macOS
- Alt+up arrow on Windows
